### PR TITLE
Add GitHub workflow for releasing to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  release:
+    types: [ 'published' ]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup Python
+      uses: actions/setup-python@v2
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Build package
+      run: pip install wheel && python setup.py sdist bdist_wheel && ls -l dist
+    - name: Publish package to TestPyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish package to PyPI
+      if: "!github.event.release.prerelease"
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
- Created [API tokens](https://pypi.org/help/#apitoken) for both [PyPI](https://pypi.org) and [TestPyPI](https://test.pypi.org) and added them as GitHub repo secrets (`PYPI_API_TOKEN` and `TEST_PYPI_API_TOKEN` respectively). 
- Added a GitHub workflow triggered whenever a [new release is published](https://github.com/TileDB-Inc/TileDB-Segy/releases/new) that:
  - Builds the package (both source and wheel distributions)
  - Uploads it to TestPyPI using the [pypi-publish](https://github.com/marketplace/actions/pypi-publish) GitHub action.
  - Uploads it to PyPI only if the release is not marked as a pre-release.

#### Demo run (on TestPyPI only):
- [GitHub action run](https://github.com/TileDB-Inc/TileDB-Segy/runs/1596553085)
- [Uploaded package](https://test.pypi.org/project/tiledb-segy/#files)

After the run I deleted the pre-release that triggered the action (and the associated tag) and reverted the temp `0.2.1.post1` version to keep things clean.